### PR TITLE
Fix gcc-14 -Wincompatible-pointer-types

### DIFF
--- a/ext/gsl_native/blas2.c
+++ b/ext/gsl_native/blas2.c
@@ -1081,8 +1081,8 @@ void Init_gsl_blas2(VALUE module)
   rb_define_module_function(module, "zher!", rb_gsl_blas_zher, 4);
   rb_define_module_function(module, "zher", rb_gsl_blas_zher_a, 4);
 
-  rb_define_module_function(module, "dsyr2!", rb_gsl_blas_dsyr2, 4);
-  rb_define_module_function(module, "dsyr2", rb_gsl_blas_dsyr2_a, 4);
-  rb_define_module_function(module, "zher2!", rb_gsl_blas_zher2, 4);
-  rb_define_module_function(module, "zher2", rb_gsl_blas_zher2_a, 4);
+  rb_define_module_function(module, "dsyr2!", rb_gsl_blas_dsyr2, 5);
+  rb_define_module_function(module, "dsyr2", rb_gsl_blas_dsyr2_a, 5);
+  rb_define_module_function(module, "zher2!", rb_gsl_blas_zher2, 5);
+  rb_define_module_function(module, "zher2", rb_gsl_blas_zher2_a, 5);
 }

--- a/ext/gsl_native/gsl.c
+++ b/ext/gsl_native/gsl.c
@@ -27,7 +27,7 @@ static VALUE rb_gsl_object_inspect(VALUE obj)
   return rb_str_new2(buf);
 }
 
-static VALUE rb_gsl_call_rescue(VALUE obj)
+static VALUE rb_gsl_call_rescue(VALUE obj, VALUE error)
 {
   return Qfalse;
 }

--- a/ext/gsl_native/gsl_narray.c
+++ b/ext/gsl_native/gsl_narray.c
@@ -731,9 +731,9 @@ void Init_gsl_narray(VALUE module)
   rb_define_alias(cNArray, "to_gslv_int_view", "to_gv_int_view");
   /*****/
 
-  rb_define_method(cgsl_matrix, "to_na", rb_gsl_matrix_to_na, 0);
+  rb_define_method(cgsl_matrix, "to_na", rb_gsl_matrix_to_na, 1);
   rb_define_alias(cgsl_matrix, "to_narray", "to_na");
-  rb_define_method(cgsl_matrix, "to_nm", rb_gsl_matrix_to_nmatrix, 0);
+  rb_define_method(cgsl_matrix, "to_nm", rb_gsl_matrix_to_nmatrix, 1);
   rb_define_alias(cgsl_matrix, "to_nmatrix", "to_nm");
   rb_define_method(cgsl_matrix, "to_na2", rb_gsl_matrix_to_na_ref, 0);
   rb_define_alias(cgsl_matrix, "to_na_ref", "to_na2");

--- a/ext/gsl_native/histogram2d.c
+++ b/ext/gsl_native/histogram2d.c
@@ -474,7 +474,7 @@ static VALUE rb_gsl_histogram2d_add(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_shift(hnew, NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_sub(VALUE obj, VALUE hh2)
@@ -489,7 +489,7 @@ static VALUE rb_gsl_histogram2d_sub(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_shift(hnew, -NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_mul(VALUE obj, VALUE hh2)
@@ -504,7 +504,7 @@ static VALUE rb_gsl_histogram2d_mul(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_scale(hnew, NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_div(VALUE obj, VALUE hh2)
@@ -519,7 +519,7 @@ static VALUE rb_gsl_histogram2d_div(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_scale(hnew, 1.0/NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_scale2(VALUE obj, VALUE val)
@@ -529,7 +529,7 @@ static VALUE rb_gsl_histogram2d_scale2(VALUE obj, VALUE val)
   Data_Get_Struct(obj, gsl_histogram2d, h1);
   hnew = gsl_histogram2d_clone(h1);
   gsl_histogram2d_scale(hnew, NUM2DBL(val));
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_shift2(VALUE obj, VALUE val)
@@ -539,7 +539,7 @@ static VALUE rb_gsl_histogram2d_shift2(VALUE obj, VALUE val)
   Data_Get_Struct(obj, gsl_histogram2d, h1);
   hnew = gsl_histogram2d_clone(h1);
   gsl_histogram2d_shift(hnew, NUM2DBL(val));
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_fwrite(VALUE obj, VALUE io)
@@ -1006,7 +1006,7 @@ void Init_gsl_histogram2d(VALUE module)
   rb_define_method(cgsl_histogram2d, "fwrite2",  rb_gsl_histogram2d_fwrite2, 1);
   rb_define_method(cgsl_histogram2d, "fread2",  rb_gsl_histogram2d_fread2, 1);
   rb_define_method(cgsl_histogram2d, "fprintf",  rb_gsl_histogram2d_fprintf, -1);
-  rb_define_method(cgsl_histogram2d, "fscanf",  rb_gsl_histogram2d_fscanf, 3);
+  rb_define_method(cgsl_histogram2d, "fscanf",  rb_gsl_histogram2d_fscanf, 1);
 
   cgsl_histogram2d_pdf = rb_define_class_under(cgsl_histogram2d, "Pdf", cGSL_Object);
 
@@ -1039,4 +1039,3 @@ void Init_gsl_histogram2d(VALUE module)
 #ifdef CHECK_HISTOGRAM2D
 #undef CHECK_HISTOGRAM2D
 #endif
-

--- a/ext/gsl_native/ieee.c
+++ b/ext/gsl_native/ieee.c
@@ -81,8 +81,8 @@ void Init_gsl_ieee(VALUE module)
   rb_define_singleton_method(mgsl_ieee, "fprintf",
                              rb_gsl_ieee_fprintf_double, -1);
   rb_define_singleton_method(mgsl_ieee, "printf",
-                             rb_gsl_ieee_printf_double, -1);
+                             rb_gsl_ieee_printf_double, 1);
   rb_define_singleton_method(mgsl_ieee, "printf_double",
-                             rb_gsl_ieee_printf_double, -1);
+                             rb_gsl_ieee_printf_double, 1);
 
 }

--- a/ext/gsl_native/interp2d.c
+++ b/ext/gsl_native/interp2d.c
@@ -15,7 +15,7 @@ VALUE cgsl_interp2d_accel; /* this is used also in spline2d.c */
 extern VALUE cgsl_vector, cgsl_matrix;
 
 static VALUE rb_gsl_interp2d_alloc(int argc, VALUE *argv, VALUE self)
-{ 
+{
   rb_gsl_interp2d *sp = NULL;
   const gsl_interp2d_type *T = NULL;
   double *xptr = NULL, *yptr = NULL, *zptr = NULL;
@@ -63,8 +63,8 @@ static VALUE rb_gsl_interp2d_init(VALUE self, VALUE xarr, VALUE yarr, VALUE zarr
 }
 
 static VALUE rb_gsl_interp_evaluate(
-  VALUE self, VALUE xarr, VALUE yarr, VALUE zarr, VALUE xx, VALUE yy, 
-    double (*eval)(const gsl_interp2d * interp, 
+  VALUE self, VALUE xarr, VALUE yarr, VALUE zarr, VALUE xx, VALUE yy,
+    double (*eval)(const gsl_interp2d * interp,
       const double xa[], const double ya[], const double za[],
       const double x, const double y, gsl_interp_accel * xacc,
       gsl_interp_accel * yacc))
@@ -77,7 +77,7 @@ static VALUE rb_gsl_interp_evaluate(
     xx = yy;
     yy = temp;
   }
-  
+
   rb_gsl_interp2d *rgi = NULL;
   double *xptr = NULL, *yptr = NULL, *zptr = NULL;
   gsl_vector *vx = NULL, *vy = NULL, *vnew = NULL;
@@ -89,19 +89,19 @@ static VALUE rb_gsl_interp_evaluate(
   Data_Get_Struct(self, rb_gsl_interp2d, rgi);
   xptr = get_vector_ptr(xarr, &stridex, &xsize);
   if (xsize != rgi->p->xsize ) {
-    rb_raise(rb_eTypeError, "size mismatch (xa:%d != %d)",  (int) xsize, 
+    rb_raise(rb_eTypeError, "size mismatch (xa:%d != %d)",  (int) xsize,
       (int) rgi->p->xsize);
   }
 
   yptr = get_vector_ptr(yarr, &stridey, &ysize);
   if (ysize != rgi->p->ysize ) {
-    rb_raise(rb_eTypeError, "size mismatch (ya:%d != %d)", (int) ysize, 
+    rb_raise(rb_eTypeError, "size mismatch (ya:%d != %d)", (int) ysize,
       (int) rgi->p->ysize);
   }
 
   zptr = get_vector_ptr(zarr, &stridez, &zsize);
   if (zsize != xsize*ysize ) {
-    rb_raise(rb_eTypeError, "size mismatch (za:%d != %d)", (int) zsize, 
+    rb_raise(rb_eTypeError, "size mismatch (za:%d != %zu)", (int) zsize,
       (int) xsize*ysize);
   }
 
@@ -145,7 +145,7 @@ static VALUE rb_gsl_interp_evaluate(
       vnew = gsl_vector_alloc(vx->size);
 
       for (i = 0; i < vx->size; i++) {
-        val = (*eval)(rgi->p, xptr, yptr, zptr, gsl_vector_get(vx, i), 
+        val = (*eval)(rgi->p, xptr, yptr, zptr, gsl_vector_get(vx, i),
           gsl_vector_get(vy, i), rgi->xacc, rgi->yacc);
         gsl_vector_set(vnew, i, val);
       }
@@ -199,7 +199,7 @@ static void rb_gsl_interp2d_define_const(VALUE self)
 }
 
 const gsl_interp2d_type* get_interp2d_type(VALUE t)
-{ 
+{
   int type;
   char name[32];
 
@@ -212,7 +212,7 @@ const gsl_interp2d_type* get_interp2d_type(VALUE t)
         case 1: return gsl_interp2d_bilinear; break;
         default:
           rb_raise(rb_eRuntimeError, "Cannot recognize type %d.\n", type);
-      } 
+      }
     case T_STRING:
       strcpy(name, STR2CSTR(t));
 

--- a/ext/gsl_native/linalg.c
+++ b/ext/gsl_native/linalg.c
@@ -92,13 +92,13 @@ static VALUE rb_gsl_linalg_LU_decomp_nmatrix(int argc, VALUE *argv, VALUE obj,
     rb_raise(rb_eRuntimeError, "square matrix required");
 
   if (flag == LINALG_DECOMP) {
-    m = rb_nmatrix_dense_create(FLOAT64, input_nmatrix->shape, 2, 
+    m = rb_nmatrix_dense_create(FLOAT64, input_nmatrix->shape, 2,
       input_nmatrix->elements, input_nmatrix->shape[0] * input_nmatrix->shape[1]);
     temp_nmatrix = NM_STORAGE_DENSE(m);
-    mv = gsl_matrix_view_array((double*)temp_nmatrix->elements, 
+    mv = gsl_matrix_view_array((double*)temp_nmatrix->elements,
       temp_nmatrix->shape[0], temp_nmatrix->shape[1]);
   } else {
-    mv = gsl_matrix_view_array((double*)input_nmatrix->elements, 
+    mv = gsl_matrix_view_array((double*)input_nmatrix->elements,
       input_nmatrix->shape[0], input_nmatrix->shape[1]);
   }
   p = gsl_permutation_alloc(mv.matrix.size1);
@@ -304,7 +304,7 @@ static VALUE rb_gsl_linalg_LU_solve_nmatrix(int argc, VALUE *argv, VALUE obj)
              argc);
   }
   input_nmatrix = NM_STORAGE_DENSE(argv[0]);
-  mv = gsl_matrix_view_array((double*) input_nmatrix->elements, 
+  mv = gsl_matrix_view_array((double*) input_nmatrix->elements,
     input_nmatrix->shape[0], input_nmatrix->shape[1]);
   CHECK_PERMUTATION(argv[1]);
   Data_Get_Struct(argv[1], gsl_permutation, p);
@@ -542,11 +542,11 @@ static VALUE rb_gsl_linalg_LU_invert_nmatrix(int argc, VALUE *argv, VALUE obj)
 
   CHECK_PERMUTATION(argv[1]);
   lu_nmatrix = NM_STORAGE_DENSE(argv[0]);
-  inv = rb_nmatrix_dense_create(FLOAT64, lu_nmatrix->shape, 2, 
+  inv = rb_nmatrix_dense_create(FLOAT64, lu_nmatrix->shape, 2,
     lu_nmatrix->elements, NM_DENSE_COUNT(argv[0]));
-  mv1 = gsl_matrix_view_array((double*)lu_nmatrix->elements, 
+  mv1 = gsl_matrix_view_array((double*)lu_nmatrix->elements,
     lu_nmatrix->shape[0], lu_nmatrix->shape[1]);
-  mv2 = gsl_matrix_view_array((double*)NM_DENSE_ELEMENTS(inv), 
+  mv2 = gsl_matrix_view_array((double*)NM_DENSE_ELEMENTS(inv),
     lu_nmatrix->shape[0], lu_nmatrix->shape[1]);
 
   Data_Get_Struct(argv[1], gsl_permutation, p);
@@ -620,7 +620,7 @@ static VALUE rb_gsl_linalg_LU_det_nmatrix(int argc, VALUE *argv, VALUE obj)
   /* no break */
   case 1:
     input_nmatrix = NM_STORAGE_DENSE(argv[0]);
-    mv = gsl_matrix_view_array((double*)input_nmatrix->elements, 
+    mv = gsl_matrix_view_array((double*)input_nmatrix->elements,
       input_nmatrix->shape[0], input_nmatrix->shape[1]);
     break;
   default:
@@ -965,7 +965,7 @@ static VALUE rb_gsl_linalg_QR_decomp_nmatrix(int argc, VALUE *argv, VALUE obj)
   shapem[0] = nm->shape[1];
   shapem[1] = nm->shape[1];
   shapev[0] = shapem[0];
-  qr = rb_nmatrix_dense_create(FLOAT64, shapem, 2, nm->elements, 
+  qr = rb_nmatrix_dense_create(FLOAT64, shapem, 2, nm->elements,
     shapem[0]*shapem[1]);
   tau = rb_nmatrix_dense_create(FLOAT64, shapev, 1, nm->elements, shapev[0]);
   mv = gsl_matrix_view_array((double*)NM_DENSE_ELEMENTS(qr), shapem[0], shapem[1]);
@@ -1696,10 +1696,10 @@ static VALUE rb_gsl_linalg_R_solve(int argc, VALUE *argv, VALUE obj)
 }
 
 /* singleton */
-static VALUE rb_gsl_linalg_QR_QRsolve(int argc, VALUE *argv, VALUE obj,
-                                      int flag)
+static VALUE rb_gsl_linalg_QR_QRsolve(VALUE argc, VALUE argv, VALUE obj,
+                                      VALUE flag)
 {
-  return rb_gsl_linalg_QRLQ_QRLQsolve(argc, argv, obj, LINALG_QR_DECOMP);
+  return rb_gsl_linalg_QRLQ_QRLQsolve((int)argc, &argv, obj, LINALG_QR_DECOMP);
 }
 
 static VALUE rb_gsl_linalg_LQ_Lsolve(int argc, VALUE *argv, VALUE obj)
@@ -1718,10 +1718,10 @@ static VALUE rb_gsl_linalg_L_solve(int argc, VALUE *argv, VALUE obj)
 }
 
 /* singleton */
-static VALUE rb_gsl_linalg_LQ_LQsolve(int argc, VALUE *argv, VALUE obj,
-                                      int flag)
+static VALUE rb_gsl_linalg_LQ_LQsolve(VALUE argc, VALUE argv, VALUE obj,
+                                      VALUE flag)
 {
-  return rb_gsl_linalg_QRLQ_QRLQsolve(argc, argv, obj, LINALG_LQ_DECOMP);
+  return rb_gsl_linalg_QRLQ_QRLQsolve((int)argc, &argv, obj, LINALG_LQ_DECOMP);
 }
 
 static VALUE rb_gsl_linalg_QRLQ_update(VALUE obj, VALUE qq, VALUE rr, VALUE ww,
@@ -4049,12 +4049,12 @@ void Init_gsl_linalg(VALUE module)
   rb_define_method(cgsl_matrix_QR, "Rsolve", rb_gsl_linalg_QR_Rsolve, -1);
 
   rb_define_module_function(mgsl_linalg_QR, "Rsvx", rb_gsl_linalg_QR_Rsvx, -1);
-  rb_define_method(cgsl_matrix_QR, "Rsvx", rb_gsl_linalg_QR_Rsvx, 1);
+  rb_define_method(cgsl_matrix_QR, "Rsvx", rb_gsl_linalg_QR_Rsvx, -1);
 
   rb_define_module_function(mgsl_linalg_QR, "unpack", rb_gsl_linalg_QR_unpack, -1);
   rb_define_method(cgsl_matrix_QR, "unpack", rb_gsl_linalg_QR_unpack, -1);
 
-  rb_define_module_function(mgsl_linalg_QR, "QRsolve", rb_gsl_linalg_QR_QRsolve, -1);
+  rb_define_module_function(mgsl_linalg_QR, "QRsolve", rb_gsl_linalg_QR_QRsolve, 3);
   rb_define_module_function(mgsl_linalg_QR, "update", rb_gsl_linalg_QR_update, 4);
 
   rb_define_method(mgsl_linalg, "R_solve", rb_gsl_linalg_R_solve, -1);
@@ -4250,12 +4250,12 @@ void Init_gsl_linalg(VALUE module)
   rb_define_method(cgsl_matrix_LQ, "Lsolve_T", rb_gsl_linalg_LQ_Lsolve, -1);
 
   rb_define_module_function(mgsl_linalg_LQ, "Lsvx_T", rb_gsl_linalg_LQ_Lsvx, -1);
-  rb_define_method(cgsl_matrix_LQ, "Lsvx_T", rb_gsl_linalg_LQ_Lsvx, 1);
+  rb_define_method(cgsl_matrix_LQ, "Lsvx_T", rb_gsl_linalg_LQ_Lsvx, -1);
 
   rb_define_module_function(mgsl_linalg_LQ, "unpack", rb_gsl_linalg_LQ_unpack, -1);
   rb_define_method(cgsl_matrix_LQ, "unpack", rb_gsl_linalg_LQ_unpack, -1);
 
-  rb_define_module_function(mgsl_linalg_LQ, "LQsolve_T", rb_gsl_linalg_LQ_LQsolve, -1);
+  rb_define_module_function(mgsl_linalg_LQ, "LQsolve_T", rb_gsl_linalg_LQ_LQsolve, 3);
   rb_define_module_function(mgsl_linalg_LQ, "update", rb_gsl_linalg_LQ_update, 4);
 
   rb_define_method(mgsl_linalg, "L_solve_T", rb_gsl_linalg_L_solve, -1);

--- a/ext/gsl_native/matrix_complex.c
+++ b/ext/gsl_native/matrix_complex.c
@@ -1424,7 +1424,7 @@ static VALUE rb_gsl_matrix_complex_arccoth(VALUE obj)
   return rb_gsl_matrix_complex_XXX_complex(obj, gsl_complex_arccoth);
 }
 
-static VALUE rb_gsl_matrix_complex_indgen_bang(int argc, VALUE *argv[], VALUE obj)
+static VALUE rb_gsl_matrix_complex_indgen_bang(int argc, VALUE argv[], VALUE obj)
 {
   gsl_matrix_complex *m = NULL;
   double start = 0, step = 1, x;

--- a/ext/gsl_native/monte.c
+++ b/ext/gsl_native/monte.c
@@ -852,7 +852,7 @@ void Init_gsl_monte(VALUE module)
   rb_define_singleton_method(cgsl_monte_function, "alloc", rb_gsl_monte_function_new, -1);
 
   rb_define_method(cgsl_monte_function, "proc", rb_gsl_monte_function_proc, 0);
-  rb_define_method(cgsl_monte_function, "eval", rb_gsl_monte_function_eval, 0);
+  rb_define_method(cgsl_monte_function, "eval", rb_gsl_monte_function_eval, 1);
   rb_define_alias(cgsl_monte_function, "call", "eval");
   rb_define_method(cgsl_monte_function, "params", rb_gsl_monte_function_params, 0);
   rb_define_method(cgsl_monte_function, "set", rb_gsl_monte_function_set_f, -1);

--- a/ext/gsl_native/multiroots.c
+++ b/ext/gsl_native/multiroots.c
@@ -99,7 +99,7 @@ static void gsl_multiroot_function_mark(gsl_multiroot_function *f)
   size_t i;
   rb_gc_mark((VALUE) f->params);
   //  for (i = 0; i < RARRAY(f->params)->len; i++)
-  for (i = 0; (int) i < RARRAY_LEN(f->params); i++)
+  for (i = 0; (int) i < RARRAY_LEN((size_t)f->params); i++)
     rb_gc_mark(rb_ary_entry((VALUE) f->params, i));
 }
 
@@ -236,7 +236,7 @@ static void gsl_multiroot_function_fdf_mark(gsl_multiroot_function_fdf *f)
   size_t i;
   rb_gc_mark((VALUE) f->params);
   //  for (i = 0; i < RARRAY(f->params)->len; i++)
-  for (i = 0; (int) i < RARRAY_LEN(f->params); i++)
+  for (i = 0; (int) i < RARRAY_LEN((size_t)f->params); i++)
     rb_gc_mark(rb_ary_entry((VALUE) f->params, i));
 }
 

--- a/ext/gsl_native/ntuple.c
+++ b/ext/gsl_native/ntuple.c
@@ -434,9 +434,9 @@ void Init_gsl_ntuple(VALUE module)
   rb_define_singleton_method(cgsl_ntuple, "create", rb_gsl_ntuple_new, -1);
   rb_define_singleton_method(cgsl_ntuple, "alloc", rb_gsl_ntuple_new, -1);
   rb_define_singleton_method(cgsl_ntuple, "open", rb_gsl_ntuple_open, -1);
-  rb_define_singleton_method(cgsl_ntuple, "close", rb_gsl_ntuple_close, 0);
+  rb_define_singleton_method(cgsl_ntuple, "close", rb_gsl_ntuple_close, 1);
 
-  rb_define_method(cgsl_ntuple, "size", rb_gsl_ntuple_size, 0);
+  rb_define_method(cgsl_ntuple, "size", rb_gsl_ntuple_size, 1);
   rb_define_method(cgsl_ntuple, "write", rb_gsl_ntuple_write, 0);
   rb_define_method(cgsl_ntuple, "bookdata", rb_gsl_ntuple_bookdata, 0);
 

--- a/ext/gsl_native/odeiv.c
+++ b/ext/gsl_native/odeiv.c
@@ -882,7 +882,7 @@ void Init_gsl_odeiv(VALUE module)
   rb_define_singleton_method(cgsl_odeiv_control, "standard_alloc", rb_gsl_odeiv_control_standard_new, 4);
   rb_define_singleton_method(cgsl_odeiv_control, "y_new", rb_gsl_odeiv_control_y_new, 2);
   rb_define_singleton_method(cgsl_odeiv_control, "yp_new", rb_gsl_odeiv_control_yp_new, 2);
-  rb_define_singleton_method(cgsl_odeiv_control, "scaled_alloc", rb_gsl_odeiv_control_scaled_new, 5);
+  rb_define_singleton_method(cgsl_odeiv_control, "scaled_alloc", rb_gsl_odeiv_control_scaled_new, 6);
 
   rb_define_method(cgsl_odeiv_control, "init", rb_gsl_odeiv_control_init, 4);
   rb_define_method(cgsl_odeiv_control, "name", rb_gsl_odeiv_control_name, 0);

--- a/ext/gsl_native/poly_source.h
+++ b/ext/gsl_native/poly_source.h
@@ -1811,9 +1811,9 @@ void FUNCTION(Init_gsl_poly,init)(VALUE module)
                              FUNCTION(rb_gsl_poly,deconv2), 2);
 
   rb_define_method(GSL_TYPE(cgsl_poly), "reduce",
-                   FUNCTION(rb_gsl_poly,reduce), 1);
-  rb_define_method(GSL_TYPE(cgsl_poly), "deriv", FUNCTION(rb_gsl_poly,deriv), 1);
-  rb_define_method(GSL_TYPE(cgsl_poly), "integ", FUNCTION(rb_gsl_poly,integ), 1);
+                   FUNCTION(rb_gsl_poly,reduce), 0);
+  rb_define_method(GSL_TYPE(cgsl_poly), "deriv", FUNCTION(rb_gsl_poly,deriv), 0);
+  rb_define_method(GSL_TYPE(cgsl_poly), "integ", FUNCTION(rb_gsl_poly,integ), 0);
 
 /*****/
 

--- a/ext/gsl_native/rng.c
+++ b/ext/gsl_native/rng.c
@@ -465,21 +465,21 @@ static VALUE rb_gsl_rng_name(VALUE obj)
   return rb_str_new2(gsl_rng_name(r));
 }
 
-static VALUE rb_gsl_rng_max(VALUE obj, VALUE s)
+static VALUE rb_gsl_rng_max(VALUE obj)
 {
   gsl_rng *r = NULL;
   Data_Get_Struct(obj, gsl_rng, r);
   return UINT2NUM(gsl_rng_max(r));
 }
 
-static VALUE rb_gsl_rng_min(VALUE obj, VALUE s)
+static VALUE rb_gsl_rng_min(VALUE obj)
 {
   gsl_rng *r = NULL;
   Data_Get_Struct(obj, gsl_rng, r);
   return UINT2NUM(gsl_rng_min(r));
 }
 
-static VALUE rb_gsl_rng_size(VALUE obj, VALUE s)
+static VALUE rb_gsl_rng_size(VALUE obj)
 {
   gsl_rng *r = NULL;
   Data_Get_Struct(obj, gsl_rng, r);

--- a/ext/gsl_native/sf_bessel.c
+++ b/ext/gsl_native/sf_bessel.c
@@ -847,7 +847,7 @@ void Init_gsl_sf_bessel(VALUE module)
   rb_define_module_function(mgsl_sf_bessel, "kl_scaled_array",  rb_gsl_sf_bessel_kl_scaled_array, 2);
   rb_define_module_function(mgsl_sf_bessel, "Jnu",  rb_gsl_sf_bessel_Jnu, 2);
   rb_define_module_function(mgsl_sf_bessel, "Jnu_e",  rb_gsl_sf_bessel_Jnu_e, 2);
-  rb_define_module_function(mgsl_sf_bessel, "sequence_Jnu_e",  rb_gsl_sf_bessel_sequence_Jnu_e, 3);
+  rb_define_module_function(mgsl_sf_bessel, "sequence_Jnu_e",  rb_gsl_sf_bessel_sequence_Jnu_e, -1);
 
   rb_define_module_function(mgsl_sf_bessel, "Ynu",  rb_gsl_sf_bessel_Ynu, 2);
   rb_define_module_function(mgsl_sf_bessel, "Ynu_e",  rb_gsl_sf_bessel_Ynu_e, 2);

--- a/ext/gsl_native/sf_ellint.c
+++ b/ext/gsl_native/sf_ellint.c
@@ -172,7 +172,7 @@ void Init_gsl_sf_ellint(VALUE module)
   rb_define_module_function(module, "ellint_P",  rb_gsl_sf_ellint_P, -1);
   rb_define_module_function(module, "ellint_P_e",  rb_gsl_sf_ellint_P_e, 4);
   rb_define_module_function(module, "ellint_D",  rb_gsl_sf_ellint_D, -1);
-  rb_define_module_function(module, "ellint_D_e",  rb_gsl_sf_ellint_D_e, 4);
+  rb_define_module_function(module, "ellint_D_e",  rb_gsl_sf_ellint_D_e, 3);
   rb_define_module_function(module, "ellint_RC",  rb_gsl_sf_ellint_RC, -1);
   rb_define_module_function(module, "ellint_RC_e",  rb_gsl_sf_ellint_RC_e, 3);
   rb_define_module_function(module, "ellint_RD",  rb_gsl_sf_ellint_RD, -1);
@@ -194,7 +194,7 @@ void Init_gsl_sf_ellint(VALUE module)
   rb_define_module_function(mgsl_sf_ellint, "P",  rb_gsl_sf_ellint_P, -1);
   rb_define_module_function(mgsl_sf_ellint, "P_e",  rb_gsl_sf_ellint_P_e, 4);
   rb_define_module_function(mgsl_sf_ellint, "D",  rb_gsl_sf_ellint_D, -1);
-  rb_define_module_function(mgsl_sf_ellint, "D_e",  rb_gsl_sf_ellint_D_e, 4);
+  rb_define_module_function(mgsl_sf_ellint, "D_e",  rb_gsl_sf_ellint_D_e, 3);
   rb_define_module_function(mgsl_sf_ellint, "RC",  rb_gsl_sf_ellint_RC, -1);
   rb_define_module_function(mgsl_sf_ellint, "RC_e",  rb_gsl_sf_ellint_RC_e, 3);
   rb_define_module_function(mgsl_sf_ellint, "RD",  rb_gsl_sf_ellint_RD, -1);

--- a/ext/gsl_native/sf_mathieu.c
+++ b/ext/gsl_native/sf_mathieu.c
@@ -147,9 +147,9 @@ static VALUE rb_gsl_sf_mathieu_a(VALUE module, VALUE order, VALUE qq)
   return sf_mathieu_eval(order, qq, gsl_sf_mathieu_a);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_a_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_a_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval(argc, argv, gsl_sf_mathieu_a_array);
+  return sf_mathieu_array_eval((int)argc, &argv, gsl_sf_mathieu_a_array);
 }
 static VALUE rb_gsl_sf_mathieu_b_e(VALUE module, VALUE order, VALUE qq)
 {
@@ -167,9 +167,9 @@ static VALUE rb_gsl_sf_mathieu_b(VALUE module, VALUE order, VALUE qq)
   return sf_mathieu_eval(order, qq, gsl_sf_mathieu_b);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_b_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_b_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval(argc, argv, gsl_sf_mathieu_b_array);
+  return sf_mathieu_array_eval((int)argc, &argv, gsl_sf_mathieu_b_array);
 }
 static VALUE rb_gsl_sf_mathieu_ce_e(VALUE module, VALUE order, VALUE qq, VALUE zz)
 {
@@ -187,9 +187,9 @@ static VALUE rb_gsl_sf_mathieu_ce(VALUE module, VALUE order, VALUE qq, VALUE zz)
   return sf_mathieu_eval_int_double2(order, qq, zz, gsl_sf_mathieu_ce);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_ce_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_ce_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval2(argc, argv, gsl_sf_mathieu_ce_array);
+  return sf_mathieu_array_eval2((int)argc, &argv, gsl_sf_mathieu_ce_array);
 }
 static VALUE rb_gsl_sf_mathieu_se_e(VALUE module, VALUE order, VALUE qq, VALUE zz)
 {
@@ -207,9 +207,9 @@ static VALUE rb_gsl_sf_mathieu_se(VALUE module, VALUE order, VALUE qq, VALUE zz)
   return sf_mathieu_eval_int_double2(order, qq, zz, gsl_sf_mathieu_se);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_se_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_se_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval2(argc, argv, gsl_sf_mathieu_se_array);
+  return sf_mathieu_array_eval2((int)argc, &argv, gsl_sf_mathieu_se_array);
 }
 
 /*****/
@@ -229,9 +229,9 @@ static VALUE rb_gsl_sf_mathieu_Mc(VALUE module, VALUE n1, VALUE n2, VALUE q, VAL
   return sf_mathieu_eval2(n1, n2, q, x, gsl_sf_mathieu_Mc);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_Mc_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_Mc_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval3(argc, argv, gsl_sf_mathieu_Mc_array);
+  return sf_mathieu_array_eval3((int)argc, &argv, gsl_sf_mathieu_Mc_array);
 }
 static VALUE rb_gsl_sf_mathieu_Ms_e(VALUE module, VALUE n1, VALUE n2, VALUE q, VALUE x)
 {
@@ -249,9 +249,9 @@ static VALUE rb_gsl_sf_mathieu_Ms(VALUE module, VALUE n1, VALUE n2, VALUE q, VAL
   return sf_mathieu_eval2(n1, n2, q, x, gsl_sf_mathieu_Ms);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_Ms_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_Ms_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval3(argc, argv, gsl_sf_mathieu_Ms_array);
+  return sf_mathieu_array_eval3((int)argc, &argv, gsl_sf_mathieu_Ms_array);
 }
 /*****/
 void Init_sf_mathieu(VALUE module)
@@ -264,20 +264,20 @@ void Init_sf_mathieu(VALUE module)
 
   rb_define_module_function(module, "mathieu_a", rb_gsl_sf_mathieu_a, 2);
   rb_define_module_function(module, "mathieu_a_e", rb_gsl_sf_mathieu_a_e, 2);
-  rb_define_module_function(module, "mathieu_a_array", rb_gsl_sf_mathieu_a_array, -1);
+  rb_define_module_function(module, "mathieu_a_array", rb_gsl_sf_mathieu_a_array, 2);
   rb_define_module_function(module, "mathieu_b", rb_gsl_sf_mathieu_b, 2);
   rb_define_module_function(module, "mathieu_b_e", rb_gsl_sf_mathieu_b_e, 2);
-  rb_define_module_function(module, "mathieu_b_array", rb_gsl_sf_mathieu_b_array, -1);
+  rb_define_module_function(module, "mathieu_b_array", rb_gsl_sf_mathieu_b_array, 2);
   rb_define_module_function(module, "mathieu_ce", rb_gsl_sf_mathieu_ce, 3);
   rb_define_module_function(module, "mathieu_ce_e", rb_gsl_sf_mathieu_ce_e, 3);
-  rb_define_module_function(module, "mathieu_ce_array", rb_gsl_sf_mathieu_ce_array, -1);
+  rb_define_module_function(module, "mathieu_ce_array", rb_gsl_sf_mathieu_ce_array, 2);
   rb_define_module_function(module, "mathieu_se", rb_gsl_sf_mathieu_se, 3);
   rb_define_module_function(module, "mathieu_se_e", rb_gsl_sf_mathieu_se_e, 3);
-  rb_define_module_function(module, "mathieu_se_array", rb_gsl_sf_mathieu_se_array, -1);
+  rb_define_module_function(module, "mathieu_se_array", rb_gsl_sf_mathieu_se_array, 2);
   rb_define_module_function(module, "mathieu_Mc", rb_gsl_sf_mathieu_Mc, 4);
   rb_define_module_function(module, "mathieu_Mc_e", rb_gsl_sf_mathieu_Mc_e, 4);
-  rb_define_module_function(module, "mathieu_Mc_array", rb_gsl_sf_mathieu_Mc_array, -1);
+  rb_define_module_function(module, "mathieu_Mc_array", rb_gsl_sf_mathieu_Mc_array, 2);
   rb_define_module_function(module, "mathieu_Ms", rb_gsl_sf_mathieu_Ms, 4);
   rb_define_module_function(module, "mathieu_Ms_e", rb_gsl_sf_mathieu_Ms_e, 4);
-  rb_define_module_function(module, "mathieu_Ms_array", rb_gsl_sf_mathieu_Ms_array, -1);
+  rb_define_module_function(module, "mathieu_Ms_array", rb_gsl_sf_mathieu_Ms_array, 2);
 }

--- a/ext/gsl_native/spline.c
+++ b/ext/gsl_native/spline.c
@@ -398,7 +398,7 @@ void Init_gsl_spline(VALUE module)
   rb_define_alias(cgsl_spline, "deriv_e", "eval_deriv_e");
   rb_define_method(cgsl_spline, "eval_deriv2_e", rb_gsl_spline_eval_deriv2_e, 1);
   rb_define_alias(cgsl_spline, "deri2v_e", "eval_deriv2_e");
-  rb_define_method(cgsl_spline, "eval_integ_e", rb_gsl_spline_eval_integ_e, 1);
+  rb_define_method(cgsl_spline, "eval_integ_e", rb_gsl_spline_eval_integ_e, 2);
   rb_define_alias(cgsl_spline, "integ_e", "eval_integ_e");
 
   rb_define_method(cgsl_spline, "info", rb_gsl_spline_info, 0);

--- a/ext/gsl_native/stats.c
+++ b/ext/gsl_native/stats.c
@@ -706,20 +706,20 @@ void Init_gsl_stats(VALUE module)
 
   /*****/
 
-  rb_define_singleton_method(mgsl_stats, "wmean", rb_gsl_stats_wmean2, -1);
-  rb_define_singleton_method(mgsl_stats, "wvariance", rb_gsl_stats_wvariance2, -1);
-  rb_define_singleton_method(mgsl_stats, "wvariance_m", rb_gsl_stats_wvariance_m2, -1);
-  rb_define_singleton_method(mgsl_stats, "wsd", rb_gsl_stats_wsd2, -1);
-  rb_define_singleton_method(mgsl_stats, "wsd_m", rb_gsl_stats_wsd_m2, -1);
+  rb_define_singleton_method(mgsl_stats, "wmean", rb_gsl_stats_wmean2, 2);
+  rb_define_singleton_method(mgsl_stats, "wvariance", rb_gsl_stats_wvariance2, 2);
+  rb_define_singleton_method(mgsl_stats, "wvariance_m", rb_gsl_stats_wvariance_m2, 3);
+  rb_define_singleton_method(mgsl_stats, "wsd", rb_gsl_stats_wsd2, 2);
+  rb_define_singleton_method(mgsl_stats, "wsd_m", rb_gsl_stats_wsd_m2, 3);
   rb_define_singleton_method(mgsl_stats, "wvariance_with_fixed_mean",
-                             rb_gsl_stats_wvariance_with_fixed_mean2, -1);
+                             rb_gsl_stats_wvariance_with_fixed_mean2, 3);
   rb_define_singleton_method(mgsl_stats, "wsd_with_fixed_mean",
-                             rb_gsl_stats_wsd_with_fixed_mean2, -1);
-  rb_define_singleton_method(mgsl_stats, "wabsdev", rb_gsl_stats_wabsdev2, -1);
-  rb_define_singleton_method(mgsl_stats, "wabsdev_m", rb_gsl_stats_wabsdev_m2, -1);
-  rb_define_singleton_method(mgsl_stats, "wskew", rb_gsl_stats_wskew2, -1);
+                             rb_gsl_stats_wsd_with_fixed_mean2, 3);
+  rb_define_singleton_method(mgsl_stats, "wabsdev", rb_gsl_stats_wabsdev2, 2);
+  rb_define_singleton_method(mgsl_stats, "wabsdev_m", rb_gsl_stats_wabsdev_m2, 3);
+  rb_define_singleton_method(mgsl_stats, "wskew", rb_gsl_stats_wskew2, 2);
   rb_define_singleton_method(mgsl_stats, "wskew_m_sd", rb_gsl_stats_wskew_m2, 4);
-  rb_define_singleton_method(mgsl_stats, "wkurtosis", rb_gsl_stats_wkurtosis2, -1);
+  rb_define_singleton_method(mgsl_stats, "wkurtosis", rb_gsl_stats_wkurtosis2, 2);
   rb_define_singleton_method(mgsl_stats, "wkurtosis_m_sd", rb_gsl_stats_wkurtosis_m2, 4);
 
   /*****/
@@ -747,12 +747,12 @@ void Init_gsl_stats(VALUE module)
   rb_define_alias(cgsl_vector, "wabsdev_m", "stats_wabsdev_m");
   rb_define_method(cgsl_vector, "stats_wskew", rb_gsl_stats_wskew, -1);
   rb_define_alias(cgsl_vector, "wskew", "stats_wskew");
-  rb_define_method(cgsl_vector, "stats_wskew_m_sd", rb_gsl_stats_wskew_m_sd, 2);
+  rb_define_method(cgsl_vector, "stats_wskew_m_sd", rb_gsl_stats_wskew_m_sd, 3);
   rb_define_alias(cgsl_vector, "wskew_m_sd", "stats_wskew_m_sd");
   rb_define_method(cgsl_vector, "stats_wkurtosis", rb_gsl_stats_wkurtosis, -1);
   rb_define_alias(cgsl_vector, "wkurtosis", "stats_wkurtosis");
   rb_define_method(cgsl_vector, "stats_wkurtosis_m_sd",
-                   rb_gsl_stats_wkurtosis_m_sd, 2);
+                   rb_gsl_stats_wkurtosis_m_sd, 3);
   rb_define_alias(cgsl_vector, "wkurtosis_m_sd", "stats_wkurtosis_m_sd");
 
   /*****/

--- a/ext/gsl_native/tamu_anova.c
+++ b/ext/gsl_native/tamu_anova.c
@@ -29,10 +29,10 @@ VALUE rb_tamu_anova_alloc(int argc, VALUE *argv, VALUE klass)
   return Data_Wrap_Struct(klass, 0, free, table);
 }
 
-VALUE rb_tamu_anova_printtable(VALUE *vTable)
+VALUE rb_tamu_anova_printtable(VALUE vTable)
 {
   struct tamu_anova_table *table;
-  Data_Get_Struct(*vTable, struct tamu_anova_table, table);
+  Data_Get_Struct(vTable, struct tamu_anova_table, table);
   tamu_anova_printtable(*table);
   return Qtrue;
 }

--- a/ext/gsl_native/vector_complex.c
+++ b/ext/gsl_native/vector_complex.c
@@ -1829,7 +1829,7 @@ static VALUE rb_gsl_vector_complex_block(VALUE obj)
   return Data_Wrap_Struct(cgsl_block_complex, 0, NULL, v->block);
 }
 
-static VALUE rb_gsl_vector_complex_indgen_bang(int argc, VALUE *argv[], VALUE obj)
+static VALUE rb_gsl_vector_complex_indgen_bang(int argc, VALUE argv[], VALUE obj)
 {
   gsl_vector_complex *v = NULL;
   double start = 0.0, step = 1.0, x;
@@ -2112,7 +2112,7 @@ void Init_gsl_vector_complex(VALUE module)
   rb_define_method(cgsl_vector_complex, "isnull", rb_gsl_vector_complex_isnull, 0);
 
   rb_define_method(cgsl_vector_complex, "matrix_view", rb_gsl_vector_complex_matrix_view, -1);
-  rb_define_method(cgsl_vector_complex, "matrix_view_with_tda", rb_gsl_vector_complex_matrix_view_with_tda, -1);
+  rb_define_method(cgsl_vector_complex, "matrix_view_with_tda", rb_gsl_vector_complex_matrix_view_with_tda, 3);
 
   rb_define_method(cgsl_vector_complex, "trans", rb_gsl_vector_complex_trans, 0);
   rb_define_alias(cgsl_vector_complex, "transpose", "trans");
@@ -2238,4 +2238,3 @@ void Init_gsl_vector_complex(VALUE module)
   rb_define_method(cgsl_vector_complex, "not_equal?", rb_gsl_vector_complex_not_equal, -1);
   rb_define_alias(cgsl_vector_complex, "!=", "not_equal?");
 }
-


### PR DESCRIPTION
Integrating non merged changes to unstable branch to be able to use this with ruby >= 3.2